### PR TITLE
Added missing <algorithmn> header file,

### DIFF
--- a/src/vectorop.cpp
+++ b/src/vectorop.cpp
@@ -15,6 +15,7 @@
 #include "comparisonop.h"
 #include <vector>
 #include <cassert>
+#include <algorithm>
 
 #ifdef MCL_APPLE_ACCELERATE
   #include <Accelerate/Accelerate.h>


### PR DESCRIPTION
The vectorops.cpp is missing the <algorithmn> header file, which can cause it to fail on certain platforms.