### PR TITLE
Added preprocessor option to disable IIR filter warning.

### DIFF
--- a/src/basicop.cpp
+++ b/src/basicop.cpp
@@ -29,8 +29,8 @@ std::vector<UInt> FindPeaksIndexes(const std::vector<Real>& vector,
   // Allocate new vectors for the indexes of the local maxima
   std::vector<UInt> indexes;
   for (Int i=1; i<(Int)(vector.size()-1); ++i) {
-    if ((vector[i] > min_peak_height) &
-        (vector[i] > vector[i-1]) &
+    if ((vector[i] > min_peak_height) &&
+        (vector[i] > vector[i-1]) &&
         (vector[i] > vector[i+1])) {
       indexes.push_back(i);
     }

--- a/src/comparisonop.cpp
+++ b/src/comparisonop.cpp
@@ -108,13 +108,13 @@ bool AreAllSmallerOrEqual(const std::vector<Real>& vector_a,
 }
 
 bool IsEqual(Complex num_a, Complex num_b, Real precision) {
-  return (std::fabs(num_a.real() - num_b.real()) < precision) &
-  (std::fabs(num_a.imag() - num_b.imag()) < precision);
+  return (std::fabs(num_a.real() - num_b.real()) < precision) &&
+    (std::fabs(num_a.imag() - num_b.imag()) < precision);
 }
 
 bool IsEqual(const Quaternion& q_a, const Quaternion& q_b) {
-  return IsEqual(q_a.w(), q_b.w()) & IsEqual(q_a.x(), q_b.x()) &
-  IsEqual(q_a.y(), q_b.y()) & IsEqual(q_a.z(), q_b.z());
+  return IsEqual(q_a.w(), q_b.w()) && IsEqual(q_a.x(), q_b.x()) &&
+    IsEqual(q_a.y(), q_b.y()) && IsEqual(q_a.z(), q_b.z());
 }
 
 
@@ -153,8 +153,8 @@ bool IsEqual(std::vector<Point> points_a, std::vector<Point> points_b) {
 bool IsEqual(const Point& point_a, const Point& point_b,
              const Real precision) {
   return mcl::IsEqual(point_a.x(), point_b.x(), precision) &&
-  mcl::IsEqual(point_a.y(), point_b.y(), precision) &&
-  mcl::IsEqual(point_a.z(), point_b.z(), precision);
+    mcl::IsEqual(point_a.y(), point_b.y(), precision) &&
+    mcl::IsEqual(point_a.z(), point_b.z(), precision);
 }
 
   

--- a/src/iirfilter.cpp
+++ b/src/iirfilter.cpp
@@ -181,12 +181,14 @@ IirFilter GainFilter(Real gain) {
 IirFilter IdenticalFilter() { return GainFilter(1.0); }
 
 IirFilter WallFilter(WallType wall_type, Real sampling_frequency) {
+#ifndef MCL_IGNORE_WALL_FILTER_WARNING
   // TODO: implement for frequencies other than 44100
   if (! IsEqual(sampling_frequency, 44100)) {
     mcl::Logger::GetInstance().LogError("Attempting to use a wall filter "
         "designed for 44100 Hz sampling frequency with a sampling frequency "
         "of %f Hz. The filter response will be inaccurate.", sampling_frequency);
   }
+#endif
   
   std::vector<Real> B;
   std::vector<Real> A;

--- a/src/vectorop.cpp
+++ b/src/vectorop.cpp
@@ -15,6 +15,7 @@
 #include "comparisonop.h"
 #include <vector>
 #include <cassert>
+#include <algorithm>
 
 #ifdef MCL_APPLE_ACCELERATE
   #include <Accelerate/Accelerate.h>

--- a/src/vectorop.cpp
+++ b/src/vectorop.cpp
@@ -15,6 +15,7 @@
 #include "comparisonop.h"
 #include <vector>
 #include <cassert>
+#include <algorithm>vect
 
 #ifdef MCL_APPLE_ACCELERATE
   #include <Accelerate/Accelerate.h>


### PR DESCRIPTION
48kHz is commonly used, so this suppresses the warning message from appearing in the logs.